### PR TITLE
corrigindo erro 'Undefined variable: formLogout'

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -47,7 +47,11 @@
             }
     @endphp
     {!! $navbar !!}
-    {!! form($formLogout) !!}
+
+    @if(Auth::check())
+        {!! form($formLogout) !!}
+    @endif
+
     @if(Session::has('message'))
         <div class="container">
             {!! Alert::success(Session::get('message'))->close() !!}


### PR DESCRIPTION
O erro acontece quando tentamos acessar o formulário de login que usa o layout app. 
Como ainda não estamos autenticados, não cai no if(Auth::check()) e então a variável $formLogout não é criada, gerando um erro na linha abaixo.
Adicionei um if para exibir o formulário de logout somente se estivermos autenticados.